### PR TITLE
Hf error message

### DIFF
--- a/src/services/ReportService.js
+++ b/src/services/ReportService.js
@@ -76,12 +76,11 @@ export const SubmitReport = async (actions, props) => {
 	const city = props.formik.values.city;
 	const zipCode = props.formik.values.zipCode;
 	const itemsToSubmit = returnModel(props, streetAddress, city, zipCode);
-
 	try {
 		const response = await CreateReport(itemsToSubmit);
 		if (HasResponseErrors(response)) {
 			const errorsReturned = GetResponseErrors(response);
-			props.Field.ErrorMsg = errorsReturned;
+			props.formik.setStatus({ responseError: errorsReturned})
 			throw new Error(errorsReturned);
 		}
 

--- a/src/services/ReportService.js
+++ b/src/services/ReportService.js
@@ -80,9 +80,11 @@ export const SubmitReport = async (actions, props) => {
 		const response = await CreateReport(itemsToSubmit);
 		if (HasResponseErrors(response)) {
 			const errorsReturned = GetResponseErrors(response);
-			props.formik.setStatus({ responseError: errorsReturned})
+			props.formik.setStatus({ responseError: errorsReturned});
 			throw new Error(errorsReturned);
 		}
+
+		props.formik.setStatus({ responseError: null});
 
 		Go(props, Routes.SubmitForm, response);
 	} catch (ex) {


### PR DESCRIPTION
Resolves the issue of setting ErrorMsg property on something that doesn't exist, and instead set a status on formik if there is an error on the form.

Note: This does not display the error on the screen, we should probably add that too, but I wanted to keep this small.

It looks like the issue in dev for not reporting an issue is caused because we are using the worng ids?

@danfox01 does that make sense?

The response from the Api is as follows:

![image](https://user-images.githubusercontent.com/1933400/61741370-b6fbd800-ad5e-11e9-8887-a59bafeb6516.png)
