### PR TITLE
Fix Provide details validation

### DIFF
--- a/src/components/ProvideDetails.jsx
+++ b/src/components/ProvideDetails.jsx
@@ -137,7 +137,7 @@ const provideDetails = props => {
 	};
 
 	const goToAdditionalPage = async (values) => {
-		const isDetailsFormValid = validateDetails(values);
+		const isDetailsFormValid = await validateDetails(values);
 
 		if (isDetailsFormValid) {
 			const addressParts = location.split(',');
@@ -171,6 +171,11 @@ const provideDetails = props => {
 	 */
 	const verifyAddress = async (address, addressProperty = 'location') => {
 		formik.setFieldTouched(addressProperty, true); // Hack since we aren't using default validation and submit
+
+		if (!address) {
+			return false;
+		}
+
 		try {
 			const addressResponse = await VerifyAddress(address);
 			if (HasResponseErrors(addressResponse)) {
@@ -207,13 +212,13 @@ const provideDetails = props => {
 	 */
 	const validateDetails = async (values) => {
 		var isValidProblem = verifyProblemComment(values.describeTheProblem);
-		var isValidAddress = await verifyAddress(values.location || '1');
+		var isValidAddress = await verifyAddress(values.location);
 		return isValidAddress && isValidProblem;
 	};
 
 	const SubmitForm = async (clickEvent) => {
 		formik.setSubmitting(true);
-		const isDetailsFormValid = validateDetails(formik.values);
+		const isDetailsFormValid = await validateDetails(formik.values);
 
 		if (isDetailsFormValid) {
 			await SubmitReport(clickEvent, props);

--- a/src/components/describeTheProblem.jsx
+++ b/src/components/describeTheProblem.jsx
@@ -1,4 +1,5 @@
 import React from "react";
+import classNames from 'classnames';
 import Alert from './Alert';
 import { GetErrorDetails } from '../utilities/FormikHelpers';
 import { Field } from "formik";
@@ -10,11 +11,13 @@ const DescribeTheProblem = ({ name, formik, pageFieldName }) => {
 		hasError,
 		message: errorMessage
 	} = GetErrorDetails(name, formik);
+	const shouldDisplayValidation = isTouched && hasError;
+	const containerCssClasses = classNames('cs-form-control', 'address-search', { 'error': shouldDisplayValidation });
+	const fieldCssClasses = classNames('text-input', { 'error': shouldDisplayValidation });
 
 	return (
 		<React.Fragment>
-			<div className={
-				errorMessage ? "cs-form-control address-search error" : "cs-form-control address-search"}>
+			<div className={containerCssClasses}>
 				<label htmlFor={name}
 
 				>{pageFieldName}</label>
@@ -22,11 +25,11 @@ const DescribeTheProblem = ({ name, formik, pageFieldName }) => {
 					component="textarea"
 					placeholder="Maximum 2,000 characters."
 					name={name}
-					className={`text-input ${errorMessage ? "error" : ""}`}
+					className={fieldCssClasses}
 					value={values[name]}
 					maxLength="2000"
 				/>
-				{isTouched && hasError && <Alert>
+				{shouldDisplayValidation && <Alert>
 					{errorMessage}
 				</Alert>}
 			</div>


### PR DESCRIPTION
Addresses #100 

- Fixed issue where the classes for the describe problem container and field were not checking to see if the field was touched
- Fixed the logic to handle the custom async validation, forgot to use await and therefore our checks never returned a bool and rather a promise, which always returned true