### PR TITLE
Subcategory warnings

### DIFF
--- a/src/components/Note.jsx
+++ b/src/components/Note.jsx
@@ -5,7 +5,7 @@ const Note = (props) => (
 	<Alert
 		className="alert-information bc_alert"
 		icon="info-circle"
-	>{props.children}</Alert>
+	><div dangerouslySetInnerHTML={{__html: props.children}}></div></Alert>
 );
 
 export default Note;

--- a/src/components/Note.jsx
+++ b/src/components/Note.jsx
@@ -1,6 +1,11 @@
 import React from 'react';
 import Alert from './Alert';
 
-const Note = (props) => <Alert className="alert-information bc_alert" icon="info-circle">{props.children}</Alert>;
+const Note = (props) => (
+	<Alert
+		className="alert-information bc_alert"
+		icon="info-circle"
+	>{props.children}</Alert>
+);
 
 export default Note;

--- a/src/components/ServiceRequestForm.jsx
+++ b/src/components/ServiceRequestForm.jsx
@@ -5,6 +5,7 @@ import { GetResponseErrors } from "../utilities/CitysourcedResponseHelpers";
 import FormContainer from './FormContainer';
 import QueryString from 'query-string';
 import Model from './Modal';
+import Note from './Note';
 import { Link } from 'react-router-dom';
 import { GetContactDetails } from '../services/authService';
 import { IsFormInComplete } from "../utilities/FormHelpers";
@@ -18,7 +19,7 @@ import AnimalColorType from './animalColorType';
 import AnimalBreedType from './animalBreedType';
 import { URLRouting, SetFieldValues } from '../utilities/FormHelpers';
 import { Go, Routes } from "../Routing";
-import { GetCategory } from '../utilities/CategoryHelpers';
+import { GetCategory, GetSubCategory } from '../utilities/CategoryHelpers';
 
 const { categoryId } = QueryString.parse(window.location.search);
 
@@ -62,6 +63,7 @@ const getID = (categories, categoryName) => {
 const ServiceRequestForm = (props, errors, touched) => {
 	const localProps = props.formik;
 	const [activeCategory, setActiveCategory] = useState({});
+	const [activeSubCategory, setActiveSubCategory] = useState({});
 	const [Categories, setCategories] = useState([]);
 	const [PetTypes, setPetTypes] = useState([]);
 	const [AnimalBreeds, setAnimalBreeds] = useState([]);
@@ -193,12 +195,11 @@ const ServiceRequestForm = (props, errors, touched) => {
 		const subCategories = Categories.flatMap(x => x.types);
 		const subInfo = getSubCategoriesIncludedDescription(subCategories, value);
 		let ID = getID(subCategories, value);
+		const subCategory = GetSubCategory(Categories, ID);
+		setActiveSubCategory(subCategory);
 		const isDisabled = getshouldDisableForm(subCategories, value);
-		const notes = getNote(subCategories, value);
-		setNotes(<div className="alert-information bc_alert" >
-			<i className="fa fa-icon fa-2x fa-info-circle"></i>
-			<p dangerouslySetInnerHTML={{ __html: notes }}></p>
-		</div>);
+		const notes = subCategory ? subCategory.note : null;
+		setNotes(<Note>{notes}</Note>);
 
 		const requestSubFields = {
 			subRequestTypeID: ID,
@@ -401,6 +402,8 @@ const ServiceRequestForm = (props, errors, touched) => {
 					handleServiceSubRequestChange={handleServiceSubRequestChange}
 					rest={rest}
 					subCategories={subCategories} />
+
+				{activeSubCategory && activeSubCategory.warning && <Note>{activeSubCategory.warning}</Note>}
 
 				{localProps.values.shouldDisableForm && notes}
 

--- a/src/components/ServiceRequestForm.jsx
+++ b/src/components/ServiceRequestForm.jsx
@@ -126,6 +126,7 @@ const ServiceRequestForm = (props, errors, touched) => {
 					return requestSubCategory;
 				}
 				const fields = {
+					Categories: result.data,
 					Tabs: resultFormFieldNames.data.Tabs,
 					RequestPage: resultFormFieldNames.data.RequestPage,
 					MapPage: resultFormFieldNames.data.MapPage,

--- a/src/components/ServiceRequestForm.jsx
+++ b/src/components/ServiceRequestForm.jsx
@@ -297,8 +297,7 @@ const ServiceRequestForm = (props, errors, touched) => {
 	}
 
 	const buttonDisableValidation = () => {
-
-		return IsFormInComplete(props.formik);
+		return IsFormInComplete(props.formik, activeCategory);
 	}
 
 	const getContactDetails = async () => {

--- a/src/utilities/FormHelpers.js
+++ b/src/utilities/FormHelpers.js
@@ -1,41 +1,41 @@
 import { returnRequestTypes } from "../utilities//returnEnvironmentItems"
 import _ from 'lodash';
 
-export const IsFormInComplete = (props) => {
+export const IsFormInComplete = (props, category) => {
+	const {
+		isAnimal: isAnimalCategory
+	} = category || {};
+	const {
+		otherAnimalTypes,
+		animalColorType,
+		petType,
+		requestType,
+		subRequestType
+	} = props.values;
 
-	let requestType = props.values['requestType'].toLowerCase();
-	let subRequestType = props.values['subRequestType'].toLowerCase();
-
-	if (requestType !== ""
-		&& subRequestType !== "") {
-		if (requestType === returnRequestTypes("requestType_petAndAnimalIssue").toLowerCase()
-			&& subRequestType !== ""
-			&& props.values['petType'] === "") {
-			return true;
-		}
-		else if (requestType === returnRequestTypes("requestType_petAndAnimalIssue").toLowerCase()
-			&& subRequestType !== ""
-			&& props.values['petType'] !== ""
-			&& (props.values['petType'].toLowerCase() === returnRequestTypes("petTypeCat").toLowerCase()
-				|| props.values['petType'].toLowerCase() === returnRequestTypes("petTypeDog").toLowerCase())
-			&& props.values['animalColorType'] === "") {
-			return true;
-		}
-		else if (requestType === returnRequestTypes("requestType_petAndAnimalIssue").toLowerCase()
-			&& subRequestType !== ""
-			&& (props.values['petType'] !== ""
-				&& (props.values['petType'].toLowerCase() === returnRequestTypes("petType_Others").toLowerCase()
-					&& props.values['otherAnimalTypes'] === ""))) {
-			return true;
-		}
-		else {
-
-			return false;
-		}
-	}
-	else {
+	if (!requestType || !subRequestType) {
 		return true;
 	}
+
+	if (isAnimalCategory) {
+		if (!petType) {
+			return true;
+		}
+
+		const isCatOrDog = petType.toLowerCase() === 'cat' || petType.toLowerCase() === 'dog';
+
+		if (isCatOrDog && !animalColorType) {
+			return true;
+		}
+
+		const isOtherPetType = petType.toLowerCase() === 'other';
+
+		if (isOtherPetType && !otherAnimalTypes) {
+			return true;
+		}
+	};
+
+	return false;
 }
 
 export const URLRouting = (categories, categoryId) =>{

--- a/src/utilities/FormHelpers.js
+++ b/src/utilities/FormHelpers.js
@@ -8,28 +8,7 @@ export const IsFormInComplete = (props) => {
 
 	if (requestType !== ""
 		&& subRequestType !== "") {
-		if (requestType === returnRequestTypes("requestType_RoadsAndSidewalks").toLowerCase()
-			&& subRequestType === returnRequestTypes("subCategory_IcyConditions").toLowerCase()) {
-			return true;
-		}
-		else if ((requestType === returnRequestTypes("requestType_WaterandSewerIssues").toLowerCase())
-			&& (subRequestType === returnRequestTypes("subCategory_SewerIssues").toLowerCase() ||
-				subRequestType === returnRequestTypes("subCategory_StormWaterIssues").toLowerCase() ||
-				subRequestType === returnRequestTypes("subCategory_WaterSupplyIssues").toLowerCase()
-			)) {
-			return true;
-		}
-		else if ((requestType === returnRequestTypes("requestType_TrashRecycleIssue").toLowerCase())
-			&& (subRequestType === returnRequestTypes("subCategory_CanOrLidLostDamaged").toLowerCase() ||
-				subRequestType === returnRequestTypes("subCategory_PropertyDamangeDuringCollecttion").toLowerCase() ||
-				subRequestType === returnRequestTypes("subCategory_RecyclingNotCollected").toLowerCase() ||
-				subRequestType === returnRequestTypes("subCategory_RequestToStartNewCollection").toLowerCase() ||
-				subRequestType === returnRequestTypes("subCategory_TrashNotCollected").toLowerCase() ||
-				subRequestType === returnRequestTypes("subCategory_YardWasteNotCollected").toLowerCase()
-			)) {
-			return true;
-		}
-		else if (requestType === returnRequestTypes("requestType_petAndAnimalIssue").toLowerCase()
+		if (requestType === returnRequestTypes("requestType_petAndAnimalIssue").toLowerCase()
 			&& subRequestType !== ""
 			&& props.values['petType'] === "") {
 			return true;

--- a/src/utilities/FormHelpers.js
+++ b/src/utilities/FormHelpers.js
@@ -11,7 +11,7 @@ export const IsFormInComplete = (props, category) => {
 		petType,
 		requestType,
 		subRequestType
-	} = props.values;
+	} = props.values || {};
 
 	if (!requestType || !subRequestType) {
 		return true;


### PR DESCRIPTION
Opened in favor of https://github.com/baltimorecounty/react-baltcogo/pull/115 based on @danfox01 comments and to avoid overwriting the changes for shouldDisableForm.

The major change can be found [here](https://github.com/baltimorecounty/react-baltcogo/compare/subcategory-warnings?expand=1#diff-4b777c29904c3198926a014170e18419R405). Web services can now add a "warning" to a subcategory that will display below the subcategory. This is how it works currently in the app.

- Adjusted note component to handle html
- Added warning to initial page, if it exists
- Fix form helper is incomplete logic to avoid checking categories and subcategories directly and rather use the animal service flag to help out.