### PR TITLE
Css fixes

### DIFF
--- a/src/App.css
+++ b/src/App.css
@@ -28,3 +28,9 @@ input::-ms-clear,
 input::-ms-reveal {
   display: none;
 }
+
+@media screen and (max-width: 576px) {
+  .dg_button {
+    width: 100%;
+  }
+}

--- a/src/components/AdditionalInformation.jsx
+++ b/src/components/AdditionalInformation.jsx
@@ -279,13 +279,18 @@ const AdditionalInformation = (props) => {
             </div>
           </div>
         )}
-        <div className="d-flex justify-content-between">
-          <SeButton text="Previous" onClick={callPreviousForm} />
+        <div className="d-md-flex justify-content-md-between d-sm-block">
+          <SeButton
+            text="Previous"
+            onClick={callPreviousForm}
+            className="d-sm-block mb-3"
+          />
           <SeButton
             text="File Your Report"
             onClick={SubmitTheForm}
             isLoading={formik.isSubmitting}
             isLoadingText="Submitting Request..."
+            className="d-sm-block mb-3"
           />
         </div>
       </Form>

--- a/src/components/AdditionalInformation.jsx
+++ b/src/components/AdditionalInformation.jsx
@@ -280,17 +280,12 @@ const AdditionalInformation = (props) => {
           </div>
         )}
         <div className="d-md-flex justify-content-md-between d-sm-block">
-          <SeButton
-            text="Previous"
-            onClick={callPreviousForm}
-            className="d-sm-block mb-3"
-          />
+          <SeButton text="Previous" onClick={callPreviousForm} />
           <SeButton
             text="File Your Report"
             onClick={SubmitTheForm}
             isLoading={formik.isSubmitting}
             isLoadingText="Submitting Request..."
-            className="d-sm-block mb-3"
           />
         </div>
       </Form>

--- a/src/components/Modal.jsx
+++ b/src/components/Modal.jsx
@@ -5,12 +5,12 @@ import {
   IconLink,
 } from "@baltimorecounty/dotgov-components";
 
-const Modal = () => {
+const Modal = (props) => {
   return (
     <div>
       <Button
         type="button"
-        className="dg_button-link dg_modal__open-button"
+        className={`dg_button-link dg_modal__open-button ${props.className}`}
         data-target="my-accessible-dialog"
         text="Why do I need to do this?"
       ></Button>

--- a/src/components/ProvideDetails.jsx
+++ b/src/components/ProvideDetails.jsx
@@ -321,17 +321,24 @@ const provideDetails = (props) => {
 
         <p className="smallest">{AdditionalInfoPage.LegalDisclaimerBottom}</p>
 
-        <div className="d-flex justify-content-between">
-          <SeButton onClick={goServiceRequestForm} text="Previous" />
+        <div className="d-md-flex justify-content-md-between d-sm-block">
+          <SeButton
+            onClick={goServiceRequestForm}
+            text="Previous"
+            className="d-sm-block mb-3"
+          />
           {!rest.formik.values.requestTypeAddressID ? (
             <SeButton
               text="File Your Report"
               onClick={SubmitForm}
               isLoading={formik.isSubmitting}
               isLoadingText="Submitting Request..."
+              className="d-sm-block mb-3"
             />
           ) : (
-            <SeButton text="Next" onClick={goToAdditionalPage} />
+            <div className="d-md-flex justify-content-md-end d-sm-block">
+              <SeButton text="Next" onClick={goToAdditionalPage} />
+            </div>
           )}
         </div>
       </Form>

--- a/src/components/ProvideDetails.jsx
+++ b/src/components/ProvideDetails.jsx
@@ -322,18 +322,13 @@ const provideDetails = (props) => {
         <p className="smallest">{AdditionalInfoPage.LegalDisclaimerBottom}</p>
 
         <div className="d-md-flex justify-content-md-between d-sm-block">
-          <SeButton
-            onClick={goServiceRequestForm}
-            text="Previous"
-            className="d-sm-block mb-3"
-          />
+          <SeButton onClick={goServiceRequestForm} text="Previous" />
           {!rest.formik.values.requestTypeAddressID ? (
             <SeButton
               text="File Your Report"
               onClick={SubmitForm}
               isLoading={formik.isSubmitting}
               isLoadingText="Submitting Request..."
-              className="d-sm-block mb-3"
             />
           ) : (
             <div className="d-md-flex justify-content-md-end d-sm-block">

--- a/src/components/ResetPasswordForm.jsx
+++ b/src/components/ResetPasswordForm.jsx
@@ -139,17 +139,12 @@ const ResetPasswordForm = (props, routeProps) => {
                   </Link>{" "}
                 </p>
                 <div className="d-md-flex justify-content-md-between d-sm-block">
-                  <SeButton
-                    text="Back"
-                    onClick={goBack}
-                    className="d-md-flex d-sm-block mb-3"
-                  />
+                  <SeButton text="Back" onClick={goBack} />
                   <SeButton
                     text="Submit Reset Request"
                     type="submit"
                     isLoading={props.isSubmitting}
                     isLoadingText="Submitting Request..."
-                    className="d-sm-block mb-3"
                   />
                 </div>
               </div>

--- a/src/components/ResetPasswordForm.jsx
+++ b/src/components/ResetPasswordForm.jsx
@@ -138,13 +138,18 @@ const ResetPasswordForm = (props, routeProps) => {
                     {ResetPasswordPage.SignInLinkLabel}
                   </Link>{" "}
                 </p>
-                <div className="d-flex justify-content-between">
-                  <SeButton text="Back" onClick={goBack} />
+                <div className="d-md-flex justify-content-md-between d-sm-block">
+                  <SeButton
+                    text="Back"
+                    onClick={goBack}
+                    className="d-md-flex d-sm-block mb-3"
+                  />
                   <SeButton
                     text="Submit Reset Request"
                     type="submit"
                     isLoading={props.isSubmitting}
                     isLoadingText="Submitting Request..."
+                    className="d-sm-block mb-3"
                   />
                 </div>
               </div>

--- a/src/components/SeButton.jsx
+++ b/src/components/SeButton.jsx
@@ -15,7 +15,7 @@ const SeButton = (props) => {
   } = props;
   const cssClasses = classNames(
     `d-sm-block mb-3 ${isDisabled ? "disabled" : ""}`,
-    ...className.split(" "),
+    className,
     { "is-loading": isLoading }
   );
 

--- a/src/components/SeButton.jsx
+++ b/src/components/SeButton.jsx
@@ -14,7 +14,7 @@ const SeButton = (props) => {
     ...rest
   } = props;
   const cssClasses = classNames(
-    `${isDisabled ? "disabled" : ""}`,
+    `d-sm-block mb-3 ${isDisabled ? "disabled" : ""}`,
     ...className.split(" "),
     { "is-loading": isLoading }
   );

--- a/src/components/ServiceRequestForm.jsx
+++ b/src/components/ServiceRequestForm.jsx
@@ -555,17 +555,19 @@ const ServiceRequestForm = (props, errors, touched) => {
 
         {displayButton ? (
           !contactID ? (
-            <div className="d-flex justify-content-between">
+            <div className="d-md-flex justify-content-md-between d-sm-block">
               <SeButton
                 text="Sign In"
                 isDisabled={disableButton}
                 onClick={callSignInForm}
+                className="d-sm-block mb-3"
               />
-              <Modal />
+              <Modal className="d-sm-block" />
               <SeButton
                 text="Register"
                 isDisabled={disableButton}
                 onClick={callRegisterForm}
+                className="d-sm-block mb-3"
               />
             </div>
           ) : (
@@ -581,7 +583,7 @@ const ServiceRequestForm = (props, errors, touched) => {
                   different account. &nbsp;{" "}
                 </Link>
               </p>
-              <div className="d-flex justify-content-end">
+              <div className="d-md-flex justify-content-md-end d-sm-block">
                 <SeButton
                   text="Next"
                   isDisabled={disableButton}

--- a/src/components/ServiceRequestForm.jsx
+++ b/src/components/ServiceRequestForm.jsx
@@ -560,14 +560,14 @@ const ServiceRequestForm = (props, errors, touched) => {
                 text="Sign In"
                 isDisabled={disableButton}
                 onClick={callSignInForm}
-                className="d-sm-block mb-3"
+                className="d-sm-block w-sm-100 mb-3"
               />
               <Modal className="d-sm-block" />
               <SeButton
                 text="Register"
                 isDisabled={disableButton}
                 onClick={callRegisterForm}
-                className="d-sm-block mb-3"
+                className="d-sm-block w-sm-100 mb-3"
               />
             </div>
           ) : (
@@ -588,6 +588,7 @@ const ServiceRequestForm = (props, errors, touched) => {
                   text="Next"
                   isDisabled={disableButton}
                   onClick={goToNextPage}
+                  style={{ width: "100%" }}
                 />
               </div>
             </div>

--- a/src/components/ServiceRequestForm.jsx
+++ b/src/components/ServiceRequestForm.jsx
@@ -560,14 +560,12 @@ const ServiceRequestForm = (props, errors, touched) => {
                 text="Sign In"
                 isDisabled={disableButton}
                 onClick={callSignInForm}
-                className="d-sm-block w-sm-100 mb-3"
               />
               <Modal className="d-sm-block" />
               <SeButton
                 text="Register"
                 isDisabled={disableButton}
                 onClick={callRegisterForm}
-                className="d-sm-block w-sm-100 mb-3"
               />
             </div>
           ) : (

--- a/src/components/ServiceRequestForm.jsx
+++ b/src/components/ServiceRequestForm.jsx
@@ -588,7 +588,6 @@ const ServiceRequestForm = (props, errors, touched) => {
                   text="Next"
                   isDisabled={disableButton}
                   onClick={goToNextPage}
-                  style={{ width: "100%" }}
                 />
               </div>
             </div>

--- a/src/components/SignInForm.jsx
+++ b/src/components/SignInForm.jsx
@@ -198,17 +198,12 @@ const SignIn = (props, routeProps) => {
                   <Link to="SignUpForm">{SignInPage.SignUpLinkLabel}</Link>
                 </p>
                 <div className="d-md-flex justify-content-md-between d-sm-block">
-                  <SeButton
-                    text="Back"
-                    onClick={goBack}
-                    className="d-sm-block mb-3"
-                  />
+                  <SeButton text="Back" onClick={goBack} />
                   <SeButton
                     text="Sign In and Continue"
                     type="submit"
                     isLoading={props.isSubmitting}
                     isLoadingText="Signing In..."
-                    className="d-sm-block mb-3"
                   />
                 </div>
               </div>

--- a/src/components/SignInForm.jsx
+++ b/src/components/SignInForm.jsx
@@ -197,13 +197,18 @@ const SignIn = (props, routeProps) => {
                   {SignInPage.NoAccountLabel}{" "}
                   <Link to="SignUpForm">{SignInPage.SignUpLinkLabel}</Link>
                 </p>
-                <div className="d-flex justify-content-between">
-                  <SeButton text="Back" onClick={goBack} />
+                <div className="d-md-flex justify-content-md-between d-sm-block">
+                  <SeButton
+                    text="Back"
+                    onClick={goBack}
+                    className="d-sm-block mb-3"
+                  />
                   <SeButton
                     text="Sign In and Continue"
                     type="submit"
                     isLoading={props.isSubmitting}
                     isLoadingText="Signing In..."
+                    className="d-sm-block mb-3"
                   />
                 </div>
               </div>

--- a/src/components/SignUpForm.jsx
+++ b/src/components/SignUpForm.jsx
@@ -265,17 +265,12 @@ const CreateAccount = (props, routeProps) => {
                   <Link to="SignInForm">{SignUpPage.SignInLinkLabel}</Link>
                 </p>
                 <div className="d-md-flex justify-content-md-between d-sm-block">
-                  <SeButton
-                    text="Back"
-                    onClick={goBack}
-                    className="d-sm-block mb-3"
-                  />
+                  <SeButton text="Back" onClick={goBack} />
                   <SeButton
                     text="Sign Up and Continue"
                     type="submit"
                     isLoading={isSubmitting}
                     isLoadingText="Signing Up..."
-                    className="d-sm-block mb-3"
                   />
                 </div>
               </div>

--- a/src/components/SignUpForm.jsx
+++ b/src/components/SignUpForm.jsx
@@ -264,13 +264,18 @@ const CreateAccount = (props, routeProps) => {
                   {SignUpPage.HaveAccountLabel}{" "}
                   <Link to="SignInForm">{SignUpPage.SignInLinkLabel}</Link>
                 </p>
-                <div className="d-flex justify-content-between">
-                  <SeButton text="Back" className="seButton" onClick={goBack} />
+                <div className="d-md-flex justify-content-md-between d-sm-block">
+                  <SeButton
+                    text="Back"
+                    onClick={goBack}
+                    className="d-block mb-3"
+                  />
                   <SeButton
                     text="Sign Up and Continue"
                     type="submit"
                     isLoading={isSubmitting}
                     isLoadingText="Signing Up..."
+                    className="d-block mb-3"
                   />
                 </div>
               </div>

--- a/src/components/SignUpForm.jsx
+++ b/src/components/SignUpForm.jsx
@@ -268,14 +268,14 @@ const CreateAccount = (props, routeProps) => {
                   <SeButton
                     text="Back"
                     onClick={goBack}
-                    className="d-block mb-3"
+                    className="d-sm-block mb-3"
                   />
                   <SeButton
                     text="Sign Up and Continue"
                     type="submit"
                     isLoading={isSubmitting}
                     isLoadingText="Signing Up..."
-                    className="d-block mb-3"
+                    className="d-sm-block mb-3"
                   />
                 </div>
               </div>


### PR DESCRIPTION
17434: BaltCoGo - Register Buttons Bleed Together at XS Breakpoint 

Modified the buttons to be responsive like the other pages in dotgov.  

A responsive media class was added to add 100% width to buttons at small screen sizes. This can be removed and added to the components library if needed but I didnt know how this would effect the library and I believe the way BaltCo was designed is what is causing this discrepancy in button widths since we are not using grid but instead using flex.