### PR TITLE
fixed the id: value pairing for pets

### DIFF
--- a/src/components/ServiceRequestForm.jsx
+++ b/src/components/ServiceRequestForm.jsx
@@ -328,26 +328,25 @@ const ServiceRequestForm = (props, errors, touched) => {
     SetFieldValues(localProps, { petTypeID: ID });
   };
 
-  const handleFieldChange = (changeEvent, lookupItems, propertyName) => {
+  const handleFieldChange = (changeEvent, propertyName) => {
     const value = changeEvent.currentTarget.value.toLowerCase();
-    const id = getID(lookupItems, value);
-    localProps.setFieldValue(propertyName, id);
+    SetFieldValues(localProps, { [propertyName]: value });
   };
 
   const handleAnimalColorChange = (changeEvent) => {
-    handleFieldChange(changeEvent, AnimalColors, "animalColorTypeID");
+    handleFieldChange(changeEvent, "animalColorTypeID");
   };
 
   const handleOtherPetTypeChange = (changeEvent) => {
-    handleFieldChange(changeEvent, OtherAnimalTypes, "otherAnimalTypesID");
+    handleFieldChange(changeEvent, "otherAnimalTypesID");
   };
 
   const handlePetSexChange = (changeEvent) => {
-    handleFieldChange(changeEvent, animalSex, "sexTypeID");
+    handleFieldChange(changeEvent, "sexTypeID");
   };
 
   const handleAnimalBreedChange = (changeEvent) => {
-    handleFieldChange(changeEvent, animalSubCategories, "animalBreedID");
+    handleFieldChange(changeEvent, "animalBreedID");
   };
 
   const checkPetType = (value) => {

--- a/src/components/animalBreedType.jsx
+++ b/src/components/animalBreedType.jsx
@@ -12,13 +12,18 @@ const AnimalBreedType = ({
   handleAnimalBreedChange,
   rest,
   animalSubCategories,
-  shouldShow
+  shouldShow,
 }) => {
-  const { animalBreedType } = rest.formik.values;
-  const handleChange = changeEvent => {
+  const { animalBreedTypeID } = rest.formik.values;
+  const handleChange = (changeEvent) => {
     const localProps = rest.formik;
-    const { name, value } = changeEvent.target;
-    localProps.setFieldValue(name, value);
+    const { name, options, selectedIndex } = changeEvent.target;
+    const selectedText = options[selectedIndex].text;
+
+    selectedIndex > 0
+      ? localProps.setFieldValue(name, selectedText)
+      : localProps.setFieldValue(name, "");
+
     localProps.setFieldTouched(name, true);
     handleAnimalBreedChange(changeEvent);
   };
@@ -41,7 +46,7 @@ const AnimalBreedType = ({
             label={pageFieldName}
             options={animalSubCategories}
             onChange={handleChange}
-            value={animalBreedType}
+            value={animalBreedTypeID}
             {...rest}
           />
           <p role="alert" className="error-message">

--- a/src/components/animalColorType.jsx
+++ b/src/components/animalColorType.jsx
@@ -13,13 +13,18 @@ const AnimalColorType = ({
   handleAnimalColorChange,
   rest,
   AnimalColors,
-  shouldShow
+  shouldShow,
 }) => {
-  const { animalColorType } = rest.formik.values;
-  const handleChange = changeEvent => {
+  const { animalColorTypeID } = rest.formik.values;
+  const handleChange = (changeEvent) => {
     const localProps = rest.formik;
-    const { name, value } = changeEvent.target;
-    localProps.setFieldValue(name, value);
+    const { name, options, selectedIndex } = changeEvent.target;
+    const selectedText = options[selectedIndex].text;
+
+    selectedIndex > 0
+      ? localProps.setFieldValue(name, selectedText)
+      : localProps.setFieldValue(name, "");
+
     localProps.setFieldTouched(name, true);
     handleAnimalColorChange(changeEvent);
   };
@@ -41,7 +46,7 @@ const AnimalColorType = ({
             label={pageFieldName}
             options={AnimalColors}
             onChange={handleChange}
-            value={animalColorType}
+            value={animalColorTypeID}
             {...rest}
           />
           <p role="alert" className="error-message">

--- a/src/components/otherAnimalTypes.jsx
+++ b/src/components/otherAnimalTypes.jsx
@@ -10,13 +10,18 @@ const OtherAnimalTypes = ({
   rest,
   handleOtherPetTypeChange,
   OtherAnimalTypes,
-  shouldShow
+  shouldShow,
 }) => {
-  const { otherAnimalTypes } = rest.formik.values;
-  const handleChange = changeEvent => {
+  const { otherAnimalTypesID } = rest.formik.values;
+  const handleChange = (changeEvent) => {
     const localProps = rest.formik;
-    const { name, value } = changeEvent.target;
-    localProps.setFieldValue(name, value);
+    const { name, options, selectedIndex } = changeEvent.target;
+    const selectedText = options[selectedIndex].text;
+
+    selectedIndex > 0
+      ? localProps.setFieldValue(name, selectedText)
+      : localProps.setFieldValue(name, "");
+
     localProps.setFieldTouched(name, true);
     handleOtherPetTypeChange(changeEvent);
   };
@@ -37,7 +42,7 @@ const OtherAnimalTypes = ({
             label={pageFieldName}
             options={OtherAnimalTypes}
             onChange={handleChange}
-            value={otherAnimalTypes}
+            value={otherAnimalTypesID}
             {...rest}
           />
           <p role="alert" className="error-message">

--- a/src/components/petType.jsx
+++ b/src/components/petType.jsx
@@ -9,10 +9,10 @@ const PetType = ({
   handleServicePetChange,
   rest,
   PetTypes,
-  shouldShow
+  shouldShow,
 }) => {
   const { petTypeID } = rest.formik.values;
-  const handleChange = changeEvent => {
+  const handleChange = (changeEvent) => {
     const localProps = rest.formik;
     const { name, options, selectedIndex } = changeEvent.target;
     const selectedText = options[selectedIndex].text;

--- a/src/components/sexType.jsx
+++ b/src/components/sexType.jsx
@@ -10,13 +10,18 @@ const SexType = ({
   rest,
   handlePetSexChange,
   animalSex,
-  shouldShow
+  shouldShow,
 }) => {
-  const { sexType } = rest.formik.values;
-  const handleChange = changeEvent => {
+  const { sexTypeID } = rest.formik.values;
+  const handleChange = (changeEvent) => {
     const localProps = rest.formik;
-    const { name, value } = changeEvent.target;
-    localProps.setFieldValue(name, value);
+    const { name, options, selectedIndex } = changeEvent.target;
+    const selectedText = options[selectedIndex].text;
+
+    selectedIndex > 0
+      ? localProps.setFieldValue(name, selectedText)
+      : localProps.setFieldValue(name, "");
+
     localProps.setFieldTouched(name, true);
     handlePetSexChange(changeEvent);
   };
@@ -36,7 +41,7 @@ const SexType = ({
             label={pageFieldName}
             options={animalSex}
             onChange={handleChange}
-            value={sexType}
+            value={sexTypeID}
             {...rest}
           />
           <p role="alert" className="error-message">


### PR DESCRIPTION
The ID and Value pairs were not populating correctly for pet types after they were switched to the select input from the component library. This resolves that issue by properly passing the ID to the selected value of the select component and matching id and value correctly in the response.